### PR TITLE
Fix DOAP syntax

### DIFF
--- a/static/DOAP.rdf
+++ b/static/DOAP.rdf
@@ -173,6 +173,8 @@
         <created>2023-10-10</created>
         <revision>1.4</revision>
       </Version>
+    </release>
+    <release>
       <Version>
         <name>Apache SIS 1.3 — data quality</name>
         <created>2022-12-25</created>


### PR DESCRIPTION
I'm having some trouble finding an authoritative reference, but it looks like a release (which is a property) may not contain multiple Versions (which is a node) in RDF/XML. The python rdflib at least doesn't support it, and whatever generates https://projects.apache.org/json/projects/sis.json and https://projects.apache.org/project.html?sis also doesn't seem to process it correctly.